### PR TITLE
Add YCBA IIIF Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Either:
 - [Tate](https://github.com/tategallery/collection)
 - [ACMI](https://github.com/ACMILabs/collection)
 - [ACMI Historic Film Screening Data](https://github.com/ACMILabs/historic-film-screenings-data)
+- Yale Center for British Art [IIIF top-level collection](https://manifests.britishart.yale.edu/collection/top)
 - others can be added to this list, cf. [gitMuseum](https://github.com/BritishMuseum/gitMuseum)
 
 ## Museums Collections APIs


### PR DESCRIPTION
YCBA publishes an IIIF Collection that contains objects for which high resolution images are available.   Each IIIF Manifest within the collection hierarchy links (via `seeAlso`) to a LIDO XML representation of the descriptive metadata for the object.